### PR TITLE
fix: Await publish and highlight limit checks in property service

### DIFF
--- a/src/services/propertyService.js
+++ b/src/services/propertyService.js
@@ -595,7 +595,7 @@ export default class PropertyService {
 
     if (property.advertiserEmail !== email) throw new ConfigurableError('Você não tem permissão para destacar este imóvel', 403);
 
-    if (this.checkPublishLimit(email) === true) throw new ConfigurableError('Limite de publicações atingido', 400);
+    if (await this.checkPublishLimit(email) === true) throw new ConfigurableError('Limite de publicações atingido', 400);
 
     await prisma.property.update({ where: { id: validatedId }, data: { isHighlight: false, isPublished: true } });
 
@@ -613,7 +613,7 @@ export default class PropertyService {
 
     if (property.advertiserEmail !== email) throw new ConfigurableError('Você não tem permissão para destacar este imóvel', 403);
 
-    if (this.checkHighlightLimit(email) === true) throw new ConfigurableError('Limite de destaques atingido', 400);
+    if (await this.checkHighlightLimit(email)) throw new ConfigurableError('Limite de destaques atingido', 400);
 
     await prisma.property.update({ where: { id: validatedId }, data: { isHighlight: true, isPublished: true } });
 


### PR DESCRIPTION
This pull request includes updates to the `PropertyService` class in `src/services/propertyService.js` to ensure asynchronous checks for property limits. The changes modify the methods to use `await`, ensuring that the limit checks are properly awaited before proceeding.

Key changes:

* [`src/services/propertyService.js`](diffhunk://#diff-0532d034f03a889c128af659d4699077e8ff2f401e2e65dca359432a9798a2c1L598-R598): Updated `checkPublishLimit` method call to use `await` to ensure the limit check is completed before throwing an error.
* [`src/services/propertyService.js`](diffhunk://#diff-0532d034f03a889c128af659d4699077e8ff2f401e2e65dca359432a9798a2c1L616-R616): Updated `checkHighlightLimit` method call to use `await` to ensure the limit check is completed before throwing an error.