### PR TITLE
fix: Restore route for fetching individual announcements

### DIFF
--- a/src/routes/announcementRoutes.js
+++ b/src/routes/announcementRoutes.js
@@ -10,8 +10,8 @@ const router = Express.Router();
 const upload = multer({ storage: multer.memoryStorage() });
 
 router.get('/valid', controller.getValidAnnouncements);
-router.get('/:id', controller.getAnnouncement);
 router.get('/', verifyJwt, verifyAdmin, controller.getAnnouncements);
+router.get('/:id', controller.getAnnouncement);
 router.put('/view/:id', controller.addViewAnnouncement);
 router.post('/', verifyJwt, verifyAdmin, upload.single('photo'), controller.createAnnouncement);
 router.delete('/:id', verifyJwt, verifyAdmin, controller.deleteAnnouncement);


### PR DESCRIPTION
This pull request includes changes to the `src/routes/announcementRoutes.js` file to reorder the route definitions for better organization and consistency.

Reordering of route definitions:

* [`src/routes/announcementRoutes.js`](diffhunk://#diff-36ab8a5a3424e219a5ea5462cfa1fc9c0b73df44d21ebdc989115ec32d8751acL13-R14): Moved the `router.get('/:id', controller.getAnnouncement)` route to be placed after the `router.get('/valid', controller.getValidAnnouncements)` route for better logical grouping and consistency.