### PR TITLE
Dev

### DIFF
--- a/prisma/migrations/20250226164115_alter_max_size_of_photo_url_in_announcements_table/migration.sql
+++ b/prisma/migrations/20250226164115_alter_max_size_of_photo_url_in_announcements_table/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `announcements` MODIFY `photo_url` VARCHAR(1024) NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -451,7 +451,7 @@ model Announcement {
   announcerName     String   @map("announcer_name")
   announcerEmail    String   @map("announcer_email")
   announcerCpf      String   @map("announcer_cpf")
-  photoUrl          String   @map("photo_url")
+  photoUrl          String   @map("photo_url") @db.VarChar(1024)
   siteUrl           String   @map("site_url")
   type              String   @map("type")
   paymentType       String?  @map("payment_type")

--- a/src/services/announcementService.js
+++ b/src/services/announcementService.js
@@ -42,8 +42,12 @@ export default class AnnouncementService {
     if (!photo) throw new ConfigurableError('Foto não informada', 400);
 
     const id = uuid();
+    // const announcerEmail = validateEmail(data.announcerEmail);
 
-    const storageRef = ref(storage, `images/announcements/${id}-${photo.originalname}`);
+    const photoName = photo.originalname.replace(/ /g, '_');
+    if (!photoName) throw new ConfigurableError('Nome do arquivo inválido', 400);
+
+    const storageRef = ref(storage, `images/announcements/${id}-${photoName}`);
     const metadata = { contentType: photo.mimetype };
     const snapshot = await uploadBytesResumable(storageRef, photo.buffer, metadata);
     const downloadUrl = await getDownloadURL(snapshot.ref);


### PR DESCRIPTION
This pull request includes changes to update the photo URL field size in the `announcements` table, modify the schema to reflect this change, and improve the handling of photo names in the `AnnouncementService`.

Database schema changes:

* [`prisma/migrations/20250226164115_alter_max_size_of_photo_url_in_announcements_table/migration.sql`](diffhunk://#diff-6c4b7a6f631a53e35d5e71c1596799b71f6400c7f905daf4ceb277aeda41be6bR1-R2): Altered the `photo_url` column in the `announcements` table to have a maximum size of 1024 characters.
* [`prisma/schema.prisma`](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL454-R454): Updated the `photoUrl` field in the `Announcement` model to use `@db.VarChar(1024)`.

Code improvements:

* [`src/services/announcementService.js`](diffhunk://#diff-9f7dc511769ed4e319c60fbcc91937ffa4643645fa25feb5c71bb3bc6693da7eR45-R50): Added validation to replace spaces with underscores in photo file names and throw an error if the file name is invalid.