### PR TITLE
fix: correct regex order in validateCreci function for proper validation of realstate and non-realstate types

### DIFF
--- a/src/validators/inputValidators.js
+++ b/src/validators/inputValidators.js
@@ -211,7 +211,7 @@ export function validateCreci(creci, isRealstate = false) {
   if (creci === null || creci === undefined) throw new ConfigurableError('O campo CRECI é obrigatório', 422);
   const sanitizedCreci = validator.escape(creci);
 
-  const creciRegex = isRealstate ? /^(CRECI-)?([A-Z]{2}\s?\d{1,15}|\d{1,15}\s?[A-Z]{2})$/ : /^(CRECI-)?([A-Z]{2}\s?J\d{1,15}|J\d{1,15}\s?[A-Z]{2})$/;
+  const creciRegex = isRealstate ? /^(CRECI-)?([A-Z]{2}\s?J\d{1,15}|J\d{1,15}\s?[A-Z]{2})$/ : /^(CRECI-)?([A-Z]{2}\s?\d{1,15}|\d{1,15}\s?[A-Z]{2})$/;
 
   if (!creciRegex.test(sanitizedCreci)) {
     throw new ConfigurableError('CRECI inválido', 400);


### PR DESCRIPTION
This pull request includes a small fix to the `validateCreci` function in `src/validators/inputValidators.js`. The change corrects the regular expression logic to properly validate CRECI identifiers based on whether the input is for real estate (`isRealstate`) or not.