### PR TITLE
feat: add highlight and publish limits for realtor and realstate types in user info

### DIFF
--- a/src/services/clientService.js
+++ b/src/services/clientService.js
@@ -51,6 +51,11 @@ export default class ClientService extends UserService {
       bio: params.bio ? validateString(params.bio) : oldUser.bio,
     };
 
+    if (['realtor', 'realstate'].includes(params.type)) {
+      infoData.highlightLimit = 30;
+      infoData.publishLimit = 2000;
+    }
+
     if (type === 'realtor') {
       infoData.cpf = null;
       infoData.rg = null;

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -122,6 +122,11 @@ export default class UserService {
       subscription: newUser.type !== 'admin' ? 'free' : null,
     };
 
+    if (['realtor', 'realstate'].includes(params.type)) {
+      newInfo.highlightLimit = 30;
+      newInfo.publishLimit = 2000;
+    }
+
     const newAddress = {
       email: newUser.email,
       street: params.street ? validateString(params.street) : null,


### PR DESCRIPTION
This pull request introduces changes to the `ClientService` and `UserService` classes to add specific limits for users of type `realtor` or `realstate`. The changes ensure that these user types have predefined `highlightLimit` and `publishLimit` values during user updates and creation.

### Updates for user type-specific limits:

* [`src/services/clientService.js`](diffhunk://#diff-aae14bc427f67f47eefdc23cd0af76f2a180174a0fbafbba7d93c02c93ed4946R54-R58): Added logic to set `highlightLimit` to 30 and `publishLimit` to 2000 for users with the type `realtor` or `realstate` during updates.
* [`src/services/userService.js`](diffhunk://#diff-32415b71edff84a546d911672214eb5d6aa4d2089a9120f25426f3bbfe529269R125-R129): Added similar logic to set `highlightLimit` and `publishLimit` for `realtor` and `realstate` users during user creation.